### PR TITLE
🔨Refactor: 새 채팅방 생성 시 latest_message 데이터 수정

### DIFF
--- a/src/chats/views.py
+++ b/src/chats/views.py
@@ -72,9 +72,7 @@ class ChatRoomCreateView(generics.CreateAPIView):
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def get_additional_context(self, chatroom, other_user):
-        latest_message_data = (
-            Message.objects.filter(room=chatroom).order_by("-created_at").values("message", "created_at").first()
-        )
+        latest_message_data = Message.objects.filter(room=chatroom).order_by("-created_at").values("message", "created_at").first()
         return {
             "latest_message": latest_message_data["message"] if latest_message_data else None,
             "latest_message_time": latest_message_data["created_at"] if latest_message_data else None,

--- a/src/chats/views.py
+++ b/src/chats/views.py
@@ -67,13 +67,13 @@ class ChatRoomCreateView(generics.CreateAPIView):
         ChatRoomUser.objects.create(chatroom=chatroom, user=other_user)
         Message.objects.create(room=chatroom, sender=other_user, message=f"반갑습니다 {other_user.nickname}입니다")
         context = self.get_serializer_context()
-        context.update(self.get_additional_context(chatroom, other_user, is_new=True))
+        context.update(self.get_additional_context(chatroom, other_user))
         serializer = self.get_serializer(chatroom, context=context)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
-    def get_additional_context(self, chatroom, other_user, is_new=False):
+    def get_additional_context(self, chatroom, other_user):
         latest_message_data = (
-            None if is_new else Message.objects.filter(room=chatroom).order_by("-created_at").values("message", "created_at").first()
+            Message.objects.filter(room=chatroom).order_by("-created_at").values("message", "created_at").first()
         )
         return {
             "latest_message": latest_message_data["message"] if latest_message_data else None,


### PR DESCRIPTION
채팅방 생성 시 자동메세지 생성 기능 추가되면서 모든 채팅방에 메세지가 존재하므로
기존에 새 채팅방 생성 후 응답값에 latest_message=None으로 해놓은 코드 수정