### PR TITLE
🔨Refactor: is_read_update 추가

### DIFF
--- a/src/chats/consumers.py
+++ b/src/chats/consumers.py
@@ -210,6 +210,8 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):
                         "sender_nickname": self.chatroom.latest_message.sender.nickname,
                         "latest_message_time": self.chatroom.latest_message_time.isoformat(),
                         "updated_user_id": self.user.id,
+                        "unread_count": 0,
+                        "is_read_update": True,
                     },
                 )
         except Exception as e:
@@ -243,10 +245,11 @@ class ChatListConsumer(AsyncJsonWebsocketConsumer):
     async def chat_list_update(self, event):
         room_id = event["id"]
         updated_user_id = event.get("updated_user_id")
+        is_read_update = event.get("is_read_update", False)
 
         # 현재 사용자가 업데이트된 사용자인 경우에만 unread_count를 가져옴
         if self.user.id == updated_user_id:
-            unread_count = await self.get_unread_count(room_id, self.user.id)
+            unread_count = event.get("unread_count") if is_read_update else await self.get_unread_count(room_id, self.user.id)
         else:
             unread_count = None
 
@@ -258,6 +261,7 @@ class ChatListConsumer(AsyncJsonWebsocketConsumer):
                 "sender_nickname": event["sender_nickname"],
                 "latest_message_time": event["latest_message_time"],
                 "unread_count": unread_count,
+                "is_read_update": is_read_update,
             }
         )
 


### PR DESCRIPTION
현재 상태 : 메세지 전송 시 채팅방 리스트 업데이트 & 웹소켓 접속시 unread_count 리셋 후 채팅방 리스트 업데이트
-> 단순 웹소켓 접속 시에는 프론트에서 채팅방 순서는 바꾸지않고 읽지않은 메세지 수만 변경해야함
-> is_read_update 필드를 추가해서 두 업데이트를 구분